### PR TITLE
Use int for represent color

### DIFF
--- a/controllers/list.go
+++ b/controllers/list.go
@@ -14,7 +14,7 @@ import (
 type CreateListInput struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Color       string `json:"color"`
+	Color       int32  `json:"color"`
 }
 
 type Lists struct {

--- a/models/list.go
+++ b/models/list.go
@@ -4,7 +4,7 @@ type List struct {
 	Base
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Color       string `json:"color"`
+	Color       int32  `json:"color"`
 	UserID      string `json:"user_id"`
 	Removed     bool   `json:"removed"`
 	Done        bool   `json:"done"`

--- a/tests/list_api_test.go
+++ b/tests/list_api_test.go
@@ -162,7 +162,7 @@ func TestListAPI(t *testing.T) {
 					Post("/v1/lists").
 					Header("Authorization", Bearer).
 					Header("Content-type", "application/json").
-					Body(`{"name": "Christmas", "description": "Materials needed for Christmas 2019 celeb", "color": "0xff0000"}`).
+					Body(`{"name": "Christmas", "description": "Materials needed for Christmas 2019 celeb", "color": 16711680}`).
 					Expect(t).
 					Status(http.StatusOK).
 					End()
@@ -170,7 +170,7 @@ func TestListAPI(t *testing.T) {
 				lists := services.FindListsByUserID(UserId)
 				assert.Equal(t, "Christmas", lists[0].Name)
 				assert.Equal(t, "Materials needed for Christmas 2019 celeb", lists[0].Description)
-				assert.Equal(t, "0xff0000", lists[0].Color)
+				assert.Equal(t, int32(16711680), lists[0].Color)
 			})
 		})
 
@@ -211,7 +211,7 @@ func TestListAPI(t *testing.T) {
 					Put(fmt.Sprintf("/v1/lists/%v", list.ID)).
 					Header("Authorization", Bearer).
 					Header("Content-type", "application/json").
-					Body(`{"name": "groceries", "description": "daily needs", "color": "0xffff00"}`).
+					Body(`{"name": "groceries", "description": "daily needs", "color": 16711680}`).
 					Expect(t).
 					Assert(jsonpath.Equal(`$.name`, "groceries")).
 					Status(http.StatusOK).
@@ -220,7 +220,7 @@ func TestListAPI(t *testing.T) {
 				lists := services.FindListsByUserID(UserId)
 				assert.Equal(t, "groceries", lists[0].Name)
 				assert.Equal(t, "daily needs", lists[0].Description)
-				assert.Equal(t, "0xffff00", lists[0].Color)
+				assert.Equal(t, int32(16711680), lists[0].Color)
 			})
 		})
 	})


### PR DESCRIPTION
## What's changed in this PR

- represent color with int instead of string