### PR TITLE
Enable marking item as done or remove when updating item

### DIFF
--- a/controllers/item.go
+++ b/controllers/item.go
@@ -17,6 +17,13 @@ type CreateItemInput struct {
 	ListID string `json:"list_id"`
 }
 
+type UpdateItemInput struct {
+	Name    string `json:"name"`
+	Count   uint   `json:"count"`
+	Done    bool   `json:"done"`
+	Removed bool   `json:"removed"`
+}
+
 func CreateItem(c *fiber.Ctx) {
 	uid := c.Locals("user").(models.User).ID
 
@@ -73,7 +80,7 @@ func UpdateItem(c *fiber.Ctx) {
 	uid := c.Locals("user").(models.User).ID
 	id := c.Params("ID")
 
-	var input CreateItemInput
+	var input UpdateItemInput
 	if err := c.BodyParser(&input); err != nil {
 		log.Println("Unable to parse input", err)
 		c.Status(400)
@@ -113,7 +120,7 @@ func UpdateItem(c *fiber.Ctx) {
 		return
 	}
 
-	var item = models.Item{Name: name, Count: input.Count}
+	var item = models.Item{Name: name, Count: input.Count, Done: input.Done, Removed: input.Removed}
 	item.ID = id
 
 	updatedItem, err := services.UpdateItem(item)

--- a/services/item.go
+++ b/services/item.go
@@ -25,7 +25,7 @@ func GetItemsByListID(listID string) ([]models.Item, error) {
 }
 
 func UpdateItem(item models.Item) (models.Item, error) {
-	if err := db.DB.Model(item).Where("id = ?", item.ID).Updates(models.Item{Name: item.Name, Count: item.Count}).Error; err != nil {
+	if err := db.DB.Model(item).Where("id = ?", item.ID).Updates(item).Error; err != nil {
 		return models.Item{}, err
 	}
 

--- a/tests/item_api_test.go
+++ b/tests/item_api_test.go
@@ -166,6 +166,38 @@ func TestItemAPI(t *testing.T) {
 					End()
 			})
 
+			g.It("should be able to mark item as done", func() {
+				apitest.New().
+					HandlerFunc(FiberToHandler(server.NewApp())).
+					Put(fmt.Sprintf("/v1/items/%v", itemID)).
+					Header("Authorization", Bearer).
+					Header("Content-type", "application/json").
+					Body(`{"done": true}`).
+					Expect(t).
+					Assert(jsonpath.Equal(`$.name`, "Egg")).
+					Assert(jsonpath.Equal(`$.count`, float64(2))).
+					Assert(jsonpath.Equal(`$.done`, true)).
+					Assert(jsonpath.Equal(`$.removed`, false)).
+					Status(http.StatusOK).
+					End()
+			})
+
+			g.It("should be able to mark item as removed", func() {
+				apitest.New().
+					HandlerFunc(FiberToHandler(server.NewApp())).
+					Put(fmt.Sprintf("/v1/items/%v", itemID)).
+					Header("Authorization", Bearer).
+					Header("Content-type", "application/json").
+					Body(`{"removed": true}`).
+					Expect(t).
+					Assert(jsonpath.Equal(`$.name`, "Egg")).
+					Assert(jsonpath.Equal(`$.count`, float64(2))).
+					Assert(jsonpath.Equal(`$.done`, false)).
+					Assert(jsonpath.Equal(`$.removed`, true)).
+					Status(http.StatusOK).
+					End()
+			})
+
 			g.It("should be able to update item name and count", func() {
 				apitest.New().
 					HandlerFunc(FiberToHandler(server.NewApp())).


### PR DESCRIPTION
## What's changed in this PR

- add `UpdateItemInput` struct for update item typing
- modify update item service to allow updating `Done` and `Removed` property of item
- add tests to test updating `Done` and `Removed` property of item via update item API