### PR TITLE
Fix cert issue with prod docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o shoplist .
 FROM debian:stretch
 
 WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/shoplist .
 
 EXPOSE 3000


### PR DESCRIPTION
## Background

To fix `Get "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com": x509: certificate signed by unknown authority` issue on prod container

## What's changed in this PR

- copy cert from builder to target docker image in docker file